### PR TITLE
Added new attribute to set the graph's stroke cap to square or round

### DIFF
--- a/FitChart/build.gradle
+++ b/FitChart/build.gradle
@@ -35,13 +35,13 @@ Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 23
-        versionCode 1
+        targetSdkVersion 27
+        versionCode 2
         versionName version
     }
     buildTypes {

--- a/FitChart/src/main/java/com/txusballesteros/widgets/FitChart.java
+++ b/FitChart/src/main/java/com/txusballesteros/widgets/FitChart.java
@@ -52,12 +52,15 @@ public class FitChart extends View {
     static final float INITIAL_ANIMATION_PROGRESS = 0.0f;
     static final float MAXIMUM_SWEEP_ANGLE = 360f;
     static final int DESIGN_MODE_SWEEP_ANGLE = 216;
+    static final int STROKE_CAP_ROUND = 0;
+    static final int STROKE_CAP_SQUARE = 1;
     private RectF drawingArea;
     private Paint backStrokePaint;
     private Paint valueDesignPaint;
     private int backStrokeColor;
     private int valueStrokeColor;
     private float strokeSize;
+    private int strokeCap;
     private float minValue = DEFAULT_MIN_VALUE;
     private float maxValue = DEFAULT_MAX_VALUE;
     private List<FitChartValue> chartValues;
@@ -121,7 +124,11 @@ public class FitChart extends View {
         Paint paint = getPaint();
         paint.setStyle(Paint.Style.STROKE);
         paint.setStrokeWidth(strokeSize);
-        paint.setStrokeCap(Paint.Cap.ROUND);
+        if (strokeCap == STROKE_CAP_SQUARE) {
+            paint.setStrokeCap(Paint.Cap.SQUARE);
+        } else {
+            paint.setStrokeCap(Paint.Cap.ROUND);
+        }
         return paint;
     }
 
@@ -176,6 +183,7 @@ public class FitChart extends View {
                     .getTheme().obtainStyledAttributes(attrs, R.styleable.FitChart, 0, 0);
             strokeSize = attributes
                     .getDimensionPixelSize(R.styleable.FitChart_strokeSize, (int) strokeSize);
+            strokeCap = attributes.getInt(R.styleable.FitChart_strokeCap, strokeCap);
             valueStrokeColor = attributes
                     .getColor(R.styleable.FitChart_valueStrokeColor, valueStrokeColor);
             backStrokeColor = attributes

--- a/FitChart/src/main/res/values/attributes.xml
+++ b/FitChart/src/main/res/values/attributes.xml
@@ -26,6 +26,10 @@
 <resources>
     <declare-styleable name="FitChart">
         <attr name="strokeSize" format="dimension|reference" />
+        <attr name="strokeCap" >
+            <enum name="round" value="0" />
+            <enum name="square" value="1" />
+        </attr>
         <attr name="valueStrokeColor" format="color|reference" />
         <attr name="backStrokeColor" format="color|reference" />
         <attr name="animationMode">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,15 +25,15 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.0"
 
     defaultConfig {
         applicationId "com.txusballesteros.widgets.app"
         minSdkVersion 14
-        targetSdkVersion 23
-        versionCode 1
-        versionName "1.0"
+        targetSdkVersion 27
+        versionCode 2
+        versionName "1.1"
     }
     buildTypes {
         release {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
  * Copyright Txus Ballesteros 2015 (@txusballesteros)
  *
  * This file is part of some open source application.
@@ -27,46 +26,47 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
     android:background="#fafafa"
-    android:padding="8dp"
-    android:gravity="center">
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="8dp">
 
     <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content">
 
         <com.txusballesteros.widgets.FitChart
+            android:id="@+id/fitChart"
             style="@style/chart_style"
             android:layout_gravity="center"
             app:animationMode="overdraw"
-            android:id="@+id/fitChart" />
+            app:strokeCap="square" />
 
         <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:gravity="center"
             android:layout_gravity="center"
+            android:gravity="center"
             android:orientation="vertical">
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:maxWidth="200dp"
-                android:textSize="20sp"
-                android:textStyle="bold"
-                android:textColor="#212121"
                 android:gravity="center"
-                android:text="2.500 steps today"/>
+                android:maxWidth="200dp"
+                android:text="2.500 steps today"
+                android:textColor="#212121"
+                android:textSize="20sp"
+                android:textStyle="bold" />
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:maxWidth="200dp"
-                android:textSize="15sp"
-                android:textColor="#757575"
                 android:gravity="center"
-                android:text="Your goal is 10.000 steps." />
+                android:maxWidth="200dp"
+                android:text="Your goal is 10.000 steps."
+                android:textColor="#757575"
+                android:textSize="15sp" />
 
         </LinearLayout>
     </FrameLayout>
@@ -76,6 +76,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:text="Add Values"/>
+        android:text="Add Values" />
 
 </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -30,15 +30,15 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
     }
 }
 
 allprojects {
     ext {
-        libraryVersion = '1.0'
+        libraryVersion = '1.1'
         mavenGroupId = 'com.txusballesteros'
         siteUrl = 'https://github.com/txusballesteros/fit-chart'
         gitUrl = 'https://github.com/txusballesteros/fit-chart.git'


### PR DESCRIPTION
- Added a new attribute to set the stroke cap of the graph, now you can set it to round (default) or square.
- Upgraded compile SDK and build tools version to 27, upgraded gradle to latest version so this runs on Oreo (Android 8.1.0) and Android Studio 3.0.
